### PR TITLE
feat: add layout, auth modal, flags and audio fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables
+VITE_API_URL=

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,52 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci || npm i
+
+      - name: Build
+        env:
+          GITHUB_ACTIONS: "true"
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/PROJECT_STRUCTURE.json
+++ b/docs/PROJECT_STRUCTURE.json
@@ -1,0 +1,120 @@
+{
+  "src": {
+    ".DS_Store": {
+      "size": 6148,
+      "mtime": 1755430833202.3892
+    },
+    "app": {
+      "audio": {
+        "analyser.ts": {
+          "size": 468,
+          "mtime": 1755431061677.2117
+        }
+      },
+      "auth": {
+        "LoginModal.test.tsx": {
+          "size": 937,
+          "mtime": 1755431161272.7886
+        },
+        "LoginModal.tsx": {
+          "size": 1872,
+          "mtime": 1755431159932.7935
+        }
+      },
+      "flags": {
+        "index.test.tsx": {
+          "size": 705,
+          "mtime": 1755431067681.1824
+        },
+        "index.tsx": {
+          "size": 1004,
+          "mtime": 1755431047437.2864
+        }
+      },
+      "layout": {
+        "AppShell.test.tsx": {
+          "size": 563,
+          "mtime": 1755431076657.1414
+        },
+        "AppShell.tsx": {
+          "size": 1160,
+          "mtime": 1755431053697.2527
+        },
+        "Logo.tsx": {
+          "size": 801,
+          "mtime": 1755431049797.2734
+        }
+      }
+    },
+    "index.css": {
+      "size": 358,
+      "mtime": 1755431249920.4917
+    },
+    "main.tsx": {
+      "size": 453,
+      "mtime": 1755431045105.3008
+    },
+    "styles": {
+      "tokens.css": {
+        "size": 730,
+        "mtime": 1755430833202.3892
+      }
+    }
+  },
+  "scripts": {
+    "build.sh": {
+      "size": 52,
+      "mtime": 1755430833202.3892
+    },
+    "dev.sh": {
+      "size": 130,
+      "mtime": 1755430833202.3892
+    },
+    "preview.sh": {
+      "size": 147,
+      "mtime": 1755430833202.3892
+    },
+    "setup-local.sh": {
+      "size": 562,
+      "mtime": 1755430833202.3892
+    }
+  },
+  "docs": {
+    "AGENT.md": {
+      "size": 1141,
+      "mtime": 1755430833198.3892
+    },
+    "CODEX_PROMPT.md": {
+      "size": 3933,
+      "mtime": 1755430833198.3892
+    },
+    "CONTRIBUTING.md": {
+      "size": 1939,
+      "mtime": 1755430833198.3892
+    },
+    "DEVELOPER_GUIDE.md": {
+      "size": 1954,
+      "mtime": 1755430833198.3892
+    },
+    "PROJECT_STRUCTURE.json": {
+      "size": 2362,
+      "mtime": 1755431232616.5488
+    },
+    "README.md": {
+      "size": 734,
+      "mtime": 1755430833198.3892
+    },
+    "UI-UX-DESIGN.md": {
+      "size": 1266,
+      "mtime": 1755430833198.3892
+    }
+  },
+  ".github": {
+    "workflows": {
+      "gh-pages.yml": {
+        "size": 962,
+        "mtime": 1755431085469.1042
+      }
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Space+Grotesk:wght@700&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TheCueRoom V2</title>
   </head>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.2.0",

--- a/src/app/audio/analyser.ts
+++ b/src/app/audio/analyser.ts
@@ -1,0 +1,15 @@
+export async function createAnalyser(ctx: AudioContext, source: MediaStreamAudioSourceNode) {
+  if (ctx.audioWorklet && (globalThis as any).crossOriginIsolated) {
+    try {
+      await ctx.audioWorklet.addModule('processor.js');
+      const node = new AudioWorkletNode(ctx, 'meter');
+      source.connect(node);
+      return node;
+    } catch (e) {
+      // fall back
+    }
+  }
+  const analyser = ctx.createAnalyser();
+  source.connect(analyser);
+  return analyser;
+}

--- a/src/app/auth/LoginModal.test.tsx
+++ b/src/app/auth/LoginModal.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import { LoginModal } from './LoginModal';
+
+function Wrapper() {
+  return (
+    <>
+      <button id="cta-join">open</button>
+      <LoginModal />
+    </>
+  );
+}
+
+describe('LoginModal accessibility', () => {
+  it('opens and closes with ESC and click outside', async () => {
+    const user = userEvent.setup();
+    render(<Wrapper />);
+    await user.click(screen.getByText('open'));
+    expect(screen.getByText('Continue with Google')).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    expect(screen.queryByText('Continue with Google')).toBeNull();
+    await user.click(screen.getByText('open'));
+    const overlay = await screen.findByTestId('login-overlay');
+    await user.click(overlay);
+    expect(screen.queryByText('Continue with Google')).toBeNull();
+  });
+});

--- a/src/app/auth/LoginModal.tsx
+++ b/src/app/auth/LoginModal.tsx
@@ -1,0 +1,43 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { useEffect, useState } from 'react';
+
+export function LoginModal() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('#cta-join') || target.closest('.js-login-link')) {
+        e.preventDefault();
+        setOpen(true);
+      }
+    };
+    document.addEventListener('click', handler);
+    return () => document.removeEventListener('click', handler);
+  }, []);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Portal>
+        <Dialog.Overlay data-testid="login-overlay" className="fixed inset-0 bg-black/50" />
+        <Dialog.Content className="fixed top-1/2 left-1/2 w-80 -translate-x-1/2 -translate-y-1/2 bg-bg p-6 rounded-2xl focus:outline-none focus:ring-2 focus:ring-focus">
+          <Dialog.Title className="text-lg font-bold mb-4">Sign In</Dialog.Title>
+          <div className="flex flex-col gap-2">
+            <button className="py-2 px-4 rounded bg-white text-black font-medium focus:outline-none focus:ring-2 focus:ring-focus">
+              Continue with Google
+            </button>
+            <button className="py-2 px-4 rounded bg-black text-white font-medium focus:outline-none focus:ring-2 focus:ring-focus border border-white/20">
+              Continue with Apple
+            </button>
+            <button className="py-2 px-4 rounded bg-accent-purple text-white font-medium focus:outline-none focus:ring-2 focus:ring-focus">
+              Continue with Instagram
+            </button>
+          </div>
+          <Dialog.Close className="absolute top-2 right-2 text-text focus:outline-none focus:ring-2 focus:ring-focus">
+            ×
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/app/flags/index.test.tsx
+++ b/src/app/flags/index.test.tsx
@@ -1,0 +1,20 @@
+import { renderHook, render } from '@testing-library/react';
+import { FlagProvider, useFlag, Flag } from './index';
+import { describe, it, expect } from 'vitest';
+
+describe('feature flags', () => {
+  it('returns enabled flag', () => {
+    const wrapper = ({ children }: any) => <FlagProvider flags={{ ai_feed: true }}>{children}</FlagProvider>;
+    const { result } = renderHook(() => useFlag('ai_feed'), { wrapper });
+    expect(result.current).toBe(true);
+  });
+
+  it('Flag component hides children when disabled', () => {
+    const { container } = render(
+      <FlagProvider>
+        <Flag name="meme_tools">hi</Flag>
+      </FlagProvider>
+    );
+    expect(container.textContent).toBe('');
+  });
+});

--- a/src/app/flags/index.tsx
+++ b/src/app/flags/index.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, ReactNode } from 'react';
+
+export type FeatureFlag =
+  | 'ai_feed'
+  | 'meme_tools'
+  | 'stage_plot'
+  | 'epk_export'
+  | 'gig_radar'
+  | 'news_rail'
+  | 'reactions_particles'
+  | 'dm_encryption_badge';
+
+type Flags = Record<FeatureFlag, boolean>;
+
+const defaultFlags: Flags = {
+  ai_feed: false,
+  meme_tools: false,
+  stage_plot: false,
+  epk_export: false,
+  gig_radar: false,
+  news_rail: false,
+  reactions_particles: false,
+  dm_encryption_badge: false,
+};
+
+const FlagContext = createContext<Flags>(defaultFlags);
+
+export function FlagProvider({ flags = {}, children }: { flags?: Partial<Flags>; children: ReactNode }) {
+  return <FlagContext.Provider value={{ ...defaultFlags, ...flags }}>{children}</FlagContext.Provider>;
+}
+
+export function useFlag(name: FeatureFlag): boolean {
+  return useContext(FlagContext)[name];
+}
+
+export function Flag({ name, children }: { name: FeatureFlag; children: ReactNode }) {
+  return useFlag(name) ? <>{children}</> : null;
+}

--- a/src/app/layout/AppShell.test.tsx
+++ b/src/app/layout/AppShell.test.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AppShell } from './AppShell';
+
+describe('AppShell', () => {
+  it('has sticky header with body scroll', () => {
+    const { container } = render(
+      <AppShell>
+        <div style={{ height: '200vh' }}>content</div>
+      </AppShell>
+    );
+    const header = container.querySelector('header');
+    expect(header?.className).toContain('sticky');
+    expect(header?.className).toContain('top-0');
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/src/app/layout/AppShell.tsx
+++ b/src/app/layout/AppShell.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+import { LoginModal } from '../auth/LoginModal';
+import { Logo } from './Logo';
+
+export function AppShell({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <LoginModal />
+      <header className="border-b border-border/50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50">
+        <div className="container mx-auto px-4 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-4">
+              <Logo />
+              <div className="hidden md:block h-6 w-px bg-border/50" />
+              <div className="hidden md:block">
+                <h1 className="text-xl font-bold text-foreground">TheCueRoom</h1>
+                <p className="text-sm text-muted-foreground">Underground Music Community</p>
+              </div>
+            </div>
+            <button id="cta-join" className="px-4 py-2 rounded-md bg-accent-lime text-black font-medium focus:outline-none focus:ring-2 focus:ring-focus">Join</button>
+          </div>
+        </div>
+      </header>
+      <main>{children}</main>
+    </>
+  );
+}

--- a/src/app/layout/Logo.tsx
+++ b/src/app/layout/Logo.tsx
@@ -1,0 +1,22 @@
+export function Logo({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      className={`w-8 h-8 ${className}`}
+      viewBox="0 0 32 32"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <style>{`
+        .spin { animation: spin 4s linear infinite; }
+        @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+        @media (prefers-reduced-motion: reduce) { .spin { animation: none; } }
+      `}</style>
+      <g className="spin" transform="translate(16,16)">
+        <circle cx="0" cy="0" r="14" fill="none" stroke="#B2FF00" strokeWidth="2" />
+      </g>
+      <text x="16" y="21" textAnchor="middle" fontSize="14" fill="#E6E8EB" fontFamily="'Space Grotesk', sans-serif">
+        TCR
+      </text>
+    </svg>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -15,24 +15,3 @@ body {
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
 }
 
-/* Reusable card aesthetic */
-.card {
-  @apply rounded-2xl shadow-soft bg-bg/80;
-  backdrop-filter: saturate(120%) blur(6px);
-  border: 1px solid rgba(255,255,255,0.04);
-}
-.card-header {
-  @apply flex items-center justify-between p-3 md:p-4 border-b border-white/5;
-}
-.card-traffic {
-  @apply flex items-center gap-1;
-}
-.card-traffic > span {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 9999px;
-}
-.card-traffic .g { background: var(--color-accent-lime); }
-.card-traffic .y { background: #E6C700; }
-.card-traffic .r { background: #F04747; }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import { AppShell } from './app/layout/AppShell';
+import { FlagProvider } from './app/flags';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <FlagProvider>
+      <AppShell>
+        <div className="p-4 text-center">Welcome to TheCueRoom V2</div>
+      </AppShell>
+    </FlagProvider>
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- add dynamic app shell with sticky header and inline SVG logo
- implement login modal with SSO options and tests
- add feature flag system and audio analyzer fallback

## Testing
- `npm i`
- `npm run dev`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1bf9534d4832993f5697cc5c64650